### PR TITLE
Add AMD GPU support with libva

### DIFF
--- a/Dockerfile.amd64.goreleaser
+++ b/Dockerfile.amd64.goreleaser
@@ -29,7 +29,7 @@ RUN set -eux; \
     caesiumclt --version
 
 # Runtime stage
-FROM jlesage/handbrake:v24.01.1
+FROM jlesage/handbrake:v25.12.1
 
 # Create non-root user for security
 RUN addgroup -g 1001 appuser && \
@@ -48,7 +48,10 @@ RUN apk update && \
         libjxl-tools \
         musl-dev \
         tzdata \
-        vips-tools && \
+        vips-tools \
+        libva \
+        libva-utils \
+        mesa-va-gallium && \
     rm -rf /var/cache/apk/*
 
 # Create symlink for libresolv compatibility

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -48,7 +48,11 @@ RUN apt-get update && \
         libc6 \
         libjxl-tools \
         libvips-tools \
-        tzdata && \
+        tzdata \
+        vainfo \
+        libva2 \
+        libva-drm2 \
+        mesa-va-drivers && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/config/storage-saver-amd-gpu/tasks.yaml
+++ b/config/storage-saver-amd-gpu/tasks.yaml
@@ -1,0 +1,63 @@
+tasks:
+  # Images: Resize to max 16MP, encode to JXL, restore metadata
+  - name: images-magick-jxl
+    command: >
+      magick "{{.src_folder}}/{{.name}}.{{.extension}}"
+      -auto-orient
+      -resize 4096x4096\>
+      ppm:- |
+      cjxl - "{{.dst_folder}}/{{.name}}-new.jxl"
+      -q 80
+      --effort=7
+      && exiftool -overwrite_original
+      -tagsfromfile "{{.src_folder}}/{{.name}}.{{.extension}}"
+      -all:all -m -Orientation=1 "{{.dst_folder}}/{{.name}}-new.jxl"
+    extensions:
+      - avif
+      - bmp
+      - gif
+      - heic
+      - heif
+      - jpeg
+      - jpg
+      - png
+      - tiff
+      - tif
+      - webp
+
+  # Videos: ffmpeg with hwaccel from AMD iGPU.
+  - name: videos-ffmpeg
+    command: >
+      ffmpeg
+      -hwaccel vaapi
+      -hwaccel_device /dev/dri/renderD128
+      -i "{{.src_folder}}/{{.name}}.{{.extension}}"
+      -vf "scale='if(gt(iw,ih),min(1920,iw),-2)':'if(gt(ih,iw),min(1920,ih),-2)':flags=lanczos,format=p010,hwupload"
+      -c:v hevc_vaapi -profile:v main10 -qp 22
+      -c:a libopus -b:a 128k
+      "{{.dst_folder}}/{{.name}}-new.mp4"
+      && exiftool -overwrite_original
+      -tagsfromfile "{{.src_folder}}/{{.name}}.{{.extension}}"
+      -all:all -m -Orient "{{.dst_folder}}/{{.name}}-new.mp4"
+    extensions:
+      - 3gp
+      - 3gpp
+      - avi
+      - av1
+      - flv
+      - hevc
+      - insv
+      - m2t
+      - m2ts
+      - m4v
+      - mkv
+      - mod
+      - mov
+      - mpe
+      - mpg
+      - mp4
+      - mts
+      - tod
+      - ts
+      - webm
+      - wmv


### PR DESCRIPTION
This enables Intel/AMD iGPU hardware acceleration for video encoding (e.g., on Ryzen 5825u CPU which is popular on NAS hardwares).