### PR TITLE
Update libjxl from v0.7.0 to v0.11.1 to fix metadata preservation in JPEG XL conversions

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -46,7 +46,9 @@ RUN apt-get update && \
         imagemagick \
         jq \
         libc6 \
-        libjxl-tools \
+        # libjxl-tools \ install it manually because in debian bookworm stable version is v0.7.0 which is old
+        libgif7 \
+        libtcmalloc-minimal4 \
         libvips-tools \
         tzdata \
         vainfo \
@@ -55,6 +57,14 @@ RUN apt-get update && \
         mesa-va-drivers && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+# install new cjxl
+RUN curl -fsSL -o /tmp/jxl-debs.tar.gz \
+    "https://github.com/libjxl/libjxl/releases/download/v0.11.1/jxl-debs-amd64-debian-bookworm-v0.11.1.tar.gz" && \
+    tar xzf /tmp/jxl-debs.tar.gz -C /tmp && \
+    dpkg -i /tmp/libjxl_0.11.1_amd64.deb && \
+    dpkg -i /tmp/jxl_0.11.1_amd64.deb && \
+    apt-get install -f -y && \
+    rm -rf /tmp/*.deb
 
 # Copy caesium-clt from builder
 COPY --from=builder /usr/local/bin/caesiumclt /usr/local/bin/caesiumclt


### PR DESCRIPTION
We're using debian bookworm which has stable version of cjxl (v0.7.0) which couldn't be automatically updated.  When using the current version of cjxl (v0.7.0) with the command:
```
cjxl --lossless_jpeg=0 -q 75 --container=1 input.jpg output.jxl
```

We got:
* Missing metadata. Despite using --container=1, the output lose all EXIF metadata (ISO, camera model, GPS location, etc.)

* Live Photo processing failures - When processing Live Photos with --lossless_jpeg=1, we get errors lile:
```
JXL_FAILURE: Tail data too large (max size = 4260096, size = 4400305)
JxlEncoderAddJPEGFrame() failed.
```
* No workaround available - cjxl advices to use the flag `--allow_jpeg_reconstruction=0`  is not working in current version

We have to update to v0.11.1 where all options available and working fine. This MR saves debian as base image and installs up to date cjxl

I dont know reasons behind choosing debian, but probably we can switch to alpine images which has newer versions

